### PR TITLE
Adiciona script para rodar eslint como watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "http-server .",
     "lint": "eslint scripts/**/*.js",
+    "lint:watch": "esw scripts/**/* --watch",
     "build": "gulp minify"
   },
   "repository": {
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "eslint": "^4.8.0",
+    "eslint-watch": "^3.1.3",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "http-server": "^0.10.0"


### PR DESCRIPTION
Adiciona biblioteca `eslint-watch` para permitir a execução do script lint no modo de watch